### PR TITLE
Feature/initialize unittesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/

--- a/GPS_Distance.Tests/DistanceMeasurerTests/MeasureUsingModifiedPythagorous_spec.cs
+++ b/GPS_Distance.Tests/DistanceMeasurerTests/MeasureUsingModifiedPythagorous_spec.cs
@@ -1,0 +1,15 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace DistanceMeasurerTests.MeasureUsingModifiedPythagorous_spec
+{
+    // Unit test stub
+    public class Given_some_precondition
+    {
+        [Fact]
+        public void Should_do_return_or_produce_a_specific_result()
+        {
+            true.Should().BeTrue();
+        }
+    }
+}

--- a/GPS_Distance.Tests/GPS_Distance.Tests.csproj
+++ b/GPS_Distance.Tests/GPS_Distance.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GPS_Distance\GPS_Distance.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GPS_Distance.Tests/UnitConverterTests/DegreesToRadians_spec.cs
+++ b/GPS_Distance.Tests/UnitConverterTests/DegreesToRadians_spec.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using GPS_Distance;
+using Xunit;
+
+namespace UnitConverterTests.DegreesToRadians_spec
+{
+    public class Given_boundary_values
+    {
+        public const double ExpectedPrecision = double.Epsilon;
+
+        [Theory]
+        [InlineData(-1, -0.017453292519943295)]
+        [InlineData(0, 0)]
+        [InlineData(1, 0.017453292519943295)]
+        [InlineData(180, 3.141592653589793)]
+        [InlineData(359, 6.265732014659643)]
+        [InlineData(360, 6.283185307179586)]
+        [InlineData(361, 6.300638599699529)]
+        public void Should_return_correctly_converted_radians(double degree, double expectedRadian)
+        {
+            // Act
+            var actualRadian = UnitConverter.DegreesToRadians(degree);
+
+            // Assert
+            actualRadian.Should().BeApproximately(expectedRadian, ExpectedPrecision);
+        }
+    }
+}

--- a/GPS_Distance.Tests/UnitConverterTests/MetresToMiles_spec.cs
+++ b/GPS_Distance.Tests/UnitConverterTests/MetresToMiles_spec.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+using GPS_Distance;
+using Xunit;
+
+namespace UnitConverterTests.MetresToMiles_spec
+{
+    public class Given_boundary_values
+    {
+        public const double ExpectedPrecision = 0.00000001;
+
+        [Theory]
+        [InlineData(-1, -0.0006213712)]
+        [InlineData(0, 0)]
+        [InlineData(1, 0.0006213712)]
+        [InlineData(2, 0.0012427424)]
+        [InlineData(1000, 0.62137)]
+        public void Should_return_correctly_converted_miles(double meters, double expectedMiles)
+        {
+            // Act
+            var actualMiles = UnitConverter.MetresToMiles(meters);
+
+            // Assert
+            actualMiles.Should().BeApproximately(expectedMiles, ExpectedPrecision);
+        }
+    }
+}

--- a/GPS_Distance.Tests/UnitConverterTests/RadiansToDegrees_spec.cs
+++ b/GPS_Distance.Tests/UnitConverterTests/RadiansToDegrees_spec.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using GPS_Distance;
+using Xunit;
+
+namespace UnitConverterTests.RadiansToDegrees_spec
+{
+    public class Given_boundary_values
+    {
+        public const double ExpectedPrecision = double.Epsilon;
+
+        [Theory]
+        [InlineData(-1, -180)]
+        [InlineData(1, 180)]
+        [InlineData(2, 360)]
+        public void Should_return_correctly_converted_degrees(double radian, double expectedDegrees)
+        {
+            // Act
+            var actualDegrees = UnitConverter.RadiansToDegrees(radian);
+
+            // Assert
+            actualDegrees.Should().BeApproximately(expectedDegrees, ExpectedPrecision);
+        }
+    }
+
+    public class Given_zero_radian
+    {
+        [Fact]
+        public void Should_return_positive_infinite()
+        {
+            // Arrange
+            double radian = 0;
+
+            // Act
+            var actualDegrees = UnitConverter.RadiansToDegrees(radian);
+
+            // Assert
+            actualDegrees.Should().Be(double.PositiveInfinity);
+        }
+    }
+}

--- a/GPS_Distance/DistanceMeasurer.cs
+++ b/GPS_Distance/DistanceMeasurer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace GPS_Distance
+{
+    /// <summary>
+    /// A helper for measuring distances using different algorithms. 
+    /// </summary>
+    public class DistanceMeasurer
+    {
+        public double MeasureUsingModifiedPythagorous(
+            Location startLocationInDegrees, 
+            Location endLocationInDegrees)
+        {
+            double lat = endLocationInDegrees.Latitude - startLocationInDegrees.Latitude;
+            double lon = endLocationInDegrees.Longitude - startLocationInDegrees.Longitude;
+
+            double squaredLat = Math.Pow(69.1 * lat, 2);
+            double squaredLon = Math.Pow(53.0 * lon, 2);
+
+            return Math.Sqrt(squaredLat + squaredLon);
+        }
+
+        public double MeasureGreaterCircle(
+            Location startLocationInRadians, 
+            Location endLocationInRedians, 
+            double equatorialEarthRadius)
+        {
+            double sineAngle = Math.Sin(startLocationInRadians.Latitude) * Math.Sin(endLocationInRedians.Latitude);
+            double cosAngle = Math.Cos(startLocationInRadians.Latitude) * Math.Cos(endLocationInRedians.Latitude) *
+                Math.Cos(endLocationInRedians.Longitude - startLocationInRadians.Longitude);
+
+            double distanceMetres = equatorialEarthRadius * Math.Acos(sineAngle + cosAngle);
+
+            return UnitConverter.MetresToMiles(distanceMetres);
+        }
+
+        public double MeasureHaversineForumla(
+            Location startLocationInRadians,
+            Location endLocationInRedians,
+            double equatorialEarthRadius)
+        {
+            double dlat = endLocationInRedians.Latitude - startLocationInRadians.Latitude;
+
+            double dlon = endLocationInRedians.Longitude - startLocationInRadians.Longitude;
+
+            double squaredSinDlat = Math.Sin(dlat / 2) * Math.Sin(dlat / 2);
+
+            double squaredSinLon = Math.Sin(dlon / 2) * Math.Sin(dlon / 2);
+
+            double squaredCos = Math.Cos(startLocationInRadians.Latitude) * Math.Cos(endLocationInRedians.Latitude);
+
+
+            double squared = squaredSinDlat + squaredSinLon * squaredCos;
+            double distanceMetres = equatorialEarthRadius * 2 * Math.Asin(Math.Sqrt(squared));
+            return UnitConverter.MetresToMiles(distanceMetres);
+        }
+    }
+}


### PR DESCRIPTION
fixes #4

- Creates a testing project for the application.
- Creates initial sample unit tests for the `UnitConverter` class.
- Refactors the measuring logic into a separate class to improve testability.

This PR doesn't include a complete test suite for all measuring logic. This is merely meant as a starting point for unit testing. 
It reflects my own experience, preferences and standards for writing and structuring tests, so feel free to comment on it, or change according to your own preferences. 

_Note: There's current one test failing for the unit conversion between degrees and radians. This is on purpose, as I suspect the conversion might be slightly incorrect._