### PR TITLE
Make use of SetProperty for view model property setters

### DIFF
--- a/GPS_Distance/ViewModels/EntryFormViewModel.cs
+++ b/GPS_Distance/ViewModels/EntryFormViewModel.cs
@@ -13,10 +13,7 @@ namespace GPS_Distance.ViewModels
         public ObservableCollection<Location> EndPointsLocations
         {
             get { return endPointLocations; }
-            set {
-                endPointLocations = value;
-                OnPropertyChanged("EndPointsLocations");
-            }
+            set { SetProperty(ref endPointLocations, value); }
         }
        
       

--- a/GPS_Distance/ViewModels/MainWindowViewModel.cs
+++ b/GPS_Distance/ViewModels/MainWindowViewModel.cs
@@ -13,11 +13,7 @@ namespace GPS_Distance.ViewModels
         public Unit SelectedUnit
         {
             get { return _selectedUnit; }
-            set
-            {
-                _selectedUnit = value;
-                OnPropertyChanged("SelectedUnit");
-            }
+            set { SetProperty(ref _selectedUnit, value); }
         }
 
         public IEnumerable<Unit> Units


### PR DESCRIPTION
Make use of SetProperty for all property setters found in view models inheriting from BaseViewModel.