### PR TITLE
Moved code-behind logic for EntryFrom to its corresponding view model.

### DIFF
--- a/GPS_Distance/Helpers/RelayCommand.cs
+++ b/GPS_Distance/Helpers/RelayCommand.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Input;
+
+namespace GPS_Distance.ViewModels
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action _action;
+
+        private readonly Func<bool> _canExecute = null;
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+
+        public RelayCommand(Action action, Func<bool> canExecute = null)
+        {
+            _action = action;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute?.Invoke() ?? true;
+        }
+
+        public void Execute(object parameter)
+        {
+            _action?.Invoke();
+        }
+    }
+
+    public class RelayCommand<T> : ICommand
+    {
+        private readonly Action<T> _action;
+
+        private readonly Func<T, bool> _canExecute = null;
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+
+        public RelayCommand(Action<T> action, Func<T, bool> canExecute = null)
+        {
+            _action = action;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute?.Invoke((T)parameter) ?? true;
+        }
+
+        public void Execute(object parameter)
+        {
+            _action?.Invoke((T)parameter);
+        }
+    }
+}

--- a/GPS_Distance/ViewModels/EntryFormViewModel.cs
+++ b/GPS_Distance/ViewModels/EntryFormViewModel.cs
@@ -3,20 +3,134 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
+using System.Windows.Input;
 
 namespace GPS_Distance.ViewModels
 {
+    //todo constrain the maximum size of the listbox 
+    //todo add scrollable to the listbox control
+
     public class EntryFormViewModel : BaseViewModel
-    {  
-        private ObservableCollection<Location> endPointLocations;
+    {
+        #region Fields
+
+        private ObservableCollection<Location> _endPointLocations;
+        private string _startLatitude;
+        private string _startLongitude;
+        private string _endLatitude;
+        private string _endLongitude;
+
+        #endregion
+
+        #region Properties
 
         public ObservableCollection<Location> EndPointsLocations
         {
-            get { return endPointLocations; }
-            set { SetProperty(ref endPointLocations, value); }
+            get => _endPointLocations;
+            set => SetProperty(ref _endPointLocations, value);
         }
-       
-      
 
+        public string StartLatitude
+        {
+            get => _startLatitude;
+            set => SetProperty(ref _startLatitude, value);
+        }
+
+        public string StartLongitude
+        {
+            get => _startLongitude;
+            set => SetProperty(ref _startLongitude, value);
+        }
+
+        public string EndLatitude
+        {
+            get => _endLatitude;
+            set => SetProperty(ref _endLatitude, value);
+        }
+
+        public string EndLongitude
+        {
+            get => _endLongitude;
+            set => SetProperty(ref _endLongitude, value);
+        }
+
+        #endregion
+
+        #region Commands
+
+        public ICommand ClearStartValuesCommand { get; }
+        public ICommand ClearEndValuesCommand { get; }
+        public ICommand AddEndPointCommand { get; }
+        public ICommand ClearEndPositionsListCommand { get; }
+        public ICommand ResetFormCommand { get; }
+        public ICommand MessureDistanceCommand { get; }
+
+        #endregion
+
+        #region Constructor
+
+        public EntryFormViewModel()
+        {
+            EndPointsLocations = new ObservableCollection<Location>();
+
+            // Setup Command
+            ClearStartValuesCommand = new RelayCommand(ClearStartValues);
+            ClearEndValuesCommand = new RelayCommand(ClearEndValues);
+            AddEndPointCommand = new RelayCommand(AddEndPoint);
+            ClearEndPositionsListCommand = new RelayCommand(ClearEndPositionsList);
+            ResetFormCommand = new RelayCommand(ResetForm);
+            MessureDistanceCommand = new RelayCommand(MessureDistance);
+        }
+
+        #endregion
+
+        #region Methods
+
+        private void ClearStartValues()
+        {
+            StartLatitude = null;
+            StartLongitude = null;
+        }
+
+        private void ClearEndValues()
+        {
+            EndLatitude = null;
+            EndLongitude = null;
+        }
+
+        private void AddEndPoint()
+        {
+            var location = new Location()
+            {
+                Latitude = double.Parse(EndLatitude),
+                Longitude = double.Parse(EndLongitude)
+            };
+
+            EndPointsLocations.Add(location);
+            ClearEndValues();
+        }
+
+        private void ClearEndPositionsList()
+        {
+            EndPointsLocations.Clear();
+        }
+
+        private void ResetForm()
+        {
+            ClearStartValues();
+            ClearEndValues();
+            ClearEndPositionsList();
+        }
+
+        private void MessureDistance()
+        {
+            //todo iterate through he list of the end points and measure there distance
+            //todo pass the values to the result tab
+            //todo navigate to the result tab
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
     }
 }

--- a/GPS_Distance/Views/EntryForm.xaml
+++ b/GPS_Distance/Views/EntryForm.xaml
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:GPS_Distance.ViewModels"
     mc:Ignorable="d"
-    DataContext=""
     d:DesignHeight="450"
     d:DesignWidth="800"
     d:DataContext="{d:DesignInstance viewModels:EntryFormViewModel, IsDesignTimeCreatable=True}"

--- a/GPS_Distance/Views/EntryForm.xaml
+++ b/GPS_Distance/Views/EntryForm.xaml
@@ -5,9 +5,12 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:GPS_Distance.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:GPS_Distance.ViewModels"
     mc:Ignorable="d"
+    DataContext=""
     d:DesignHeight="450"
     d:DesignWidth="800"
+    d:DataContext="{d:DesignInstance viewModels:EntryFormViewModel, IsDesignTimeCreatable=True}"
     >
 
     <Grid Background="white">
@@ -45,7 +48,7 @@
                     Content="Latitude"
                     FontSize="14" />
                 <TextBox
-                    x:Name="StartLatTxtBx"
+                    Text="{Binding StartLatitude}"
                     Width="150"
                     Height="25"
                     Margin="11,0,0,0"
@@ -57,19 +60,17 @@
                 Orientation="Horizontal">
                 <Label Content="Longitude" FontSize="14" />
                 <TextBox
-                    x:Name="StartLonTxtBx"
+                    Text="{Binding StartLongitude}"
                     Width="150"
                     Height="25"
                     TextAlignment="Center" />
             </StackPanel>
             <Button
-                x:Name="ClearStartValuesBtn"
+                Command="{Binding ClearStartValuesCommand}"
                 Style="{StaticResource BtnRed}"
                 Width="110"
                 Height="25"               
-                Click="ClearStartValuesBtn_Click"
                 Content="Clear start values"
-               
                 />
         </StackPanel>
         <StackPanel Grid.Row="2">
@@ -90,7 +91,7 @@
                     Content="Latitude"
                     FontSize="14" />
                 <TextBox
-                    x:Name="EndLatTxtBx"
+                    Text="{Binding EndLatitude}"
                     Width="150"
                     Height="25"
                     Margin="11,0,0,0"
@@ -102,23 +103,22 @@
                 Orientation="Horizontal">
                 <Label Content="Longitude" FontSize="14" />
                 <TextBox
-                    x:Name="EndLonTxtBx"
+                    Text="{Binding EndLongitude}"
                     Width="150"
                     Height="25"
                     TextAlignment="Center" />
             </StackPanel>
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
-                    x:Name="ClearEndValuesBtn"
+                    Command="{Binding ClearEndValuesCommand}"
                     Style="{StaticResource BtnRed}"
-                    Click="ClearEndValuesBtn_Click"
                     Content="Clear start values" />
                 <Button
-                    x:Name="AddEndPointBtn"
+                    Command="{Binding AddEndPointCommand}"
                     Margin="10,0,0,0"
                     Style="{StaticResource BtnGreen}"
                     Content="Add EndPoint" 
-                    Click="AddEndPointBtn_Click"/>
+                    />
             </StackPanel>
         </StackPanel>
         <StackPanel
@@ -131,7 +131,6 @@
                 FontSize="20"
                 FontWeight="Bold" />
             <ListBox
-                x:Name="EndGPSPointsListBox"
                 MinHeight="250"
                 Margin="10,5"
                 ItemsSource="{Binding EndPointsLocations}"
@@ -152,27 +151,25 @@
                 HorizontalAlignment="Center"
                 Orientation="Horizontal">
                 <Button
-                    x:Name="ClearEndGPSListBtn"
+                    Command="{Binding ClearEndPositionsListCommand}"
                     Margin="0,0,25,0"
-                   Style="{StaticResource BtnRed}"
+                    Style="{StaticResource BtnRed}"
                     Content="Clear List"
-                    Click="ClearEndGPSListBtn_Click"
                     />
                 <Button
-                    x:Name="MeasureDistanceBtn"
-                   Style="{StaticResource BtnGreen}"
+                    Command="{Binding MessureDistanceCommand}"
+                    Style="{StaticResource BtnGreen}"
                     Content="Measure Distances"
-                    Click="MeasureDistanceBtn_Click"
                     />
             </StackPanel>
-            <Button
-                x:Name="ClearAllBtn"
+                <Button
+                Command="{Binding ResetFormCommand}"
                 Margin="0,15,0,0"
                 HorizontalAlignment="Center"
                 Style="{StaticResource BtnRed}"
                 Content="Reset Form"
-                Click="ClearAllBtn_Click"/>
-        </StackPanel>
+                />
+            </StackPanel>
     </Grid>
 
 </UserControl>

--- a/GPS_Distance/Views/EntryForm.xaml.cs
+++ b/GPS_Distance/Views/EntryForm.xaml.cs
@@ -21,79 +21,10 @@ namespace GPS_Distance.Views
     /// </summary>
     public partial class EntryForm : UserControl
     {
-        //todo constrain the maximum size of the listbox 
-        //todo add scrollable to the listbox control
-
-
-        private EntryFormViewModel vm  = new EntryFormViewModel();
         public EntryForm()
         {
-             InitializeComponent();
-           
-            vm.EndPointsLocations = new ObservableCollection<Location> ();
-            DataContext = vm;
-            EndGPSPointsListBox.ItemsSource = vm.EndPointsLocations;
-            
+            InitializeComponent();
+            DataContext = new EntryFormViewModel();
         }
-        private void MeasureDistanceBtn_Click(object sender, RoutedEventArgs e)
-        {
-            //todo iterate through he list of the end points and measure there distance
-            //todo pass the values to the result tab
-            //todo navigate to the result tab
-        }
-
-        private void AddEndPointBtn_Click(object sender, RoutedEventArgs e)
-        {
-           //Todo clear endpoint entry boxes
-
-            var location = new Location() {
-                Latitude = double.Parse(EndLatTxtBx.Text),
-                Longitude = double.Parse(EndLonTxtBx.Text)
-            };
-
-            try
-            {
-    vm.EndPointsLocations.Add(location); 
-            }
-            catch (Exception ex )
-            {
-
-                Console.WriteLine(ex); 
-            }
-        
-          
-
-        }
-
-        #region clearvalues
-        private void ClearStartValuesBtn_Click(object sender, RoutedEventArgs e)
-        {
-            StartLatTxtBx.Text = "";
-            StartLonTxtBx.Text = "";
-        }
-
-        private void ClearEndValuesBtn_Click(object sender, RoutedEventArgs e)
-        {
-            EndLatTxtBx.Text = "";
-            EndLonTxtBx.Text = "";
-        }
-
-        private void ClearEndGPSListBtn_Click(object sender, RoutedEventArgs e)
-        {
-            //TODO reset List of end point
-
-        }
-
-
-
-        private void ClearAllBtn_Click(object sender, RoutedEventArgs e)
-        {
-            ClearStartValuesBtn_Click(this, e);
-            ClearEndValuesBtn_Click(this, e);
-            ClearEndGPSListBtn_Click(this, e);
-        }
-
-        #endregion clearvalues  
-
     }
 }


### PR DESCRIPTION
Hi!

Seeing that there was a view model for the control EntryFrom and still a lot of logic in the code-behind i decided to move it all into the view model.

This pull request does not change the behavior of the application and is intended to keep the logic seperate from the view.

To achieve this i have also added a basic implementation of ICommand (RelayCommand) for invoking the methods in the view model

If this is not what you had in mind or not a route you want to go please feel free to just close this pull request.