### PR TITLE
Added validation to check that the latitude and longitude values are valid

### DIFF
--- a/GPS_Distance/ViewModels/ValidationBaseViewModel.cs
+++ b/GPS_Distance/ViewModels/ValidationBaseViewModel.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace GPS_Distance.ViewModels
+{
+    public class ValidationBaseViewModel : BaseViewModel, INotifyDataErrorInfo
+    {
+        private readonly Dictionary<string, List<string>> _errors = new Dictionary<string, List<string>>();
+        private readonly object _lock = new object();
+
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
+        public bool HasErrors => _errors.Any(x => x.Value.Any());
+
+        public IEnumerable GetErrors(string propertyName)
+        {
+            if (propertyName is null)
+                lock (_lock) return _errors.SelectMany(x => x.Value.ToList()).ToList();
+
+            return _errors.TryGetValue(propertyName, out var values) ? values.ToList() : null;
+        }
+
+        public void OnErrorsChanged([CallerMemberName]string propertyName = null)
+        {
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        }
+
+        public bool ValidateProperty<T>(T value, Predicate<T> validator, string error, [CallerMemberName]string propertyName = null)
+        {
+            var valid = validator(value);
+            lock (_lock) _errors[propertyName] = valid ? new List<string>() : new List<string>() { error };
+
+            OnErrorsChanged(propertyName);
+            return valid;
+        }
+    }
+}

--- a/GPS_Distance/Views/EntryForm.xaml
+++ b/GPS_Distance/Views/EntryForm.xaml
@@ -87,8 +87,8 @@
                     Text="{Binding StartLongitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
-                    TextAlignment="Center" 
-                    Validation.ErrorTemplate="{StaticResource validationErrorTemplate}"/>
+                    TextAlignment="Center"
+                    />
             </StackPanel>
             <Button
                 Command="{Binding ClearStartValuesCommand}"

--- a/GPS_Distance/Views/EntryForm.xaml
+++ b/GPS_Distance/Views/EntryForm.xaml
@@ -12,6 +12,31 @@
     d:DataContext="{d:DesignInstance viewModels:EntryFormViewModel, IsDesignTimeCreatable=True}"
     >
 
+    <UserControl.Resources>
+        <ControlTemplate x:Key="validationErrorTemplate">
+            <Grid>
+                <Border BorderBrush="Red" BorderThickness="1">
+                    <AdornedElementPlaceholder x:Name="adorner" ToolTip="Test"/>
+                </Border>
+
+                <Polygon 
+                    Points="9,9 9,0 0,0"
+                    Stroke="Red"
+                    StrokeThickness="1"
+                    Fill="Red"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    ToolTip="{Binding ElementName=adorner, Path=AdornedElement.(Validation.Errors)[0].ErrorContent}" 
+                    />
+            </Grid>
+        </ControlTemplate>
+
+        <Style TargetType="{x:Type TextBox}" >
+            <Setter Property="Validation.ErrorTemplate" Value="{StaticResource validationErrorTemplate}" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+    </UserControl.Resources>
+
     <Grid Background="white">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -47,7 +72,7 @@
                     Content="Latitude"
                     FontSize="14" />
                 <TextBox
-                    Text="{Binding StartLatitude}"
+                    Text="{Binding StartLatitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
                     Margin="11,0,0,0"
@@ -59,16 +84,16 @@
                 Orientation="Horizontal">
                 <Label Content="Longitude" FontSize="14" />
                 <TextBox
-                    Text="{Binding StartLongitude}"
+                    Text="{Binding StartLongitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
-                    TextAlignment="Center" />
+                    TextAlignment="Center" 
+                    Validation.ErrorTemplate="{StaticResource validationErrorTemplate}"/>
             </StackPanel>
             <Button
                 Command="{Binding ClearStartValuesCommand}"
                 Style="{StaticResource BtnRed}"
                 Width="110"
-                Height="25"               
                 Content="Clear start values"
                 />
         </StackPanel>
@@ -90,7 +115,7 @@
                     Content="Latitude"
                     FontSize="14" />
                 <TextBox
-                    Text="{Binding EndLatitude}"
+                    Text="{Binding EndLatitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
                     Margin="11,0,0,0"
@@ -102,7 +127,7 @@
                 Orientation="Horizontal">
                 <Label Content="Longitude" FontSize="14" />
                 <TextBox
-                    Text="{Binding EndLongitude}"
+                    Text="{Binding EndLongitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
                     TextAlignment="Center" />
@@ -161,14 +186,14 @@
                     Content="Measure Distances"
                     />
             </StackPanel>
-                <Button
+            <Button
                 Command="{Binding ResetFormCommand}"
                 Margin="0,15,0,0"
                 HorizontalAlignment="Center"
                 Style="{StaticResource BtnRed}"
                 Content="Reset Form"
                 />
-            </StackPanel>
+        </StackPanel>
     </Grid>
 
 </UserControl>


### PR DESCRIPTION
Added validation to the latitude and longitude text boxes using the INotifyDataErrorInfo interface.

If the validation fails a red border is shown around the text box and if you hover the triangle in the corner a tooltip with the error message is shown.

Fixes feature-request #9