### PR TITLE
Allow comma as a decimal point for input.

### DIFF
--- a/GPS_Distance/ViewModels/EntryFormViewModel.cs
+++ b/GPS_Distance/ViewModels/EntryFormViewModel.cs
@@ -1,10 +1,8 @@
-﻿using GPS_Distance.Models;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Text;
+﻿using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 using System.Windows.Input;
+
+using GPS_Distance.Models;
 
 namespace GPS_Distance.ViewModels
 {
@@ -165,20 +163,22 @@ namespace GPS_Distance.ViewModels
 
         private bool TryParseLatitude(string input, out double latitude)
         {
-            var regex = @"^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$";
+            var regex = @"^(?:\+|-)?(?:90(?:(?:(?:\.|,)0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:(?:\.|,)[0-9]{1,6})?))$";
+
             return TryParseRegexToDouble(input, regex, out latitude);
         }
 
         private bool TryParseLongitude(string input, out double longitude)
         {
-            var regex = @"^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$";
+            var regex = @"^(?:\+|-)?(?:180(?:(?:(?:\.|,)0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:(?:\.|,)[0-9]{1,6})?))$";
+
             return TryParseRegexToDouble(input, regex, out longitude);
         }
 
         private bool TryParseRegexToDouble(string input, string regex, out double value)
         {
             var valid = !string.IsNullOrWhiteSpace(input) && Regex.IsMatch(input, regex);
-            value = valid ? double.Parse(input) : 0;
+            value = valid ? double.Parse(input.Replace(',', '.'), System.Globalization.NumberFormatInfo.InvariantInfo) : 0;
 
             return valid;
         }

--- a/GPS_Distance/Views/EntryForm.xaml
+++ b/GPS_Distance/Views/EntryForm.xaml
@@ -26,8 +26,7 @@
                     Fill="Red"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
-                    ToolTip="{Binding ElementName=adorner, Path=AdornedElement.(Validation.Errors)[0].ErrorContent}" 
-                    />
+                    ToolTip="{Binding ElementName=adorner, Path=AdornedElement.(Validation.Errors)[0].ErrorContent}"/>
             </Grid>
         </ControlTemplate>
 
@@ -84,18 +83,10 @@
                 Orientation="Horizontal">
                 <Label Content="Longitude" FontSize="14" />
                 <TextBox
-
-                    Width="150"
-                    Height="25"
-               
-                    TextAlignment="Center" />
-
                     Text="{Binding StartLongitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
-                    TextAlignment="Center"
-                    />
-
+                    TextAlignment="Center"/>
             </StackPanel>
             <Button
                 Width="110"
@@ -122,7 +113,7 @@
                     Content="Latitude"
                     FontSize="14" />
                 <TextBox
-                         Text="{Binding EndLatitude, UpdateSourceTrigger=PropertyChanged}"
+                    Text="{Binding EndLatitude, UpdateSourceTrigger=PropertyChanged}"
                     Width="150"
                     Height="25"
                     Margin="11,0,0,0"                    
@@ -142,7 +133,7 @@
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     Command="{Binding ClearEndValuesCommand}"
-                    Content="Clear start values"
+                    Content="Clear end values"
                     Style="{StaticResource BtnRed}" />
                 <Button
                     Margin="10,0,0,0"


### PR DESCRIPTION
Hi,

Thanks for sharing this project, but I found a problem.

Not everyone drives several miles(!) on the wrong side of the road and fill their petrol tank with gallons(!)...  ;-)

Where I live, we use comma (,) as decimal separator. I think we have a catch-22 situation. Regex doesn't allow me to input comma (,) and in my language Parse throws an error with a period (.).

I think this can be accomplished several ways but as a start:

1. Regex allows point OR comma for input.
2. Replace comma with point after input.
3. Always use point for Parse(input).

Regards,